### PR TITLE
Feature/tag

### DIFF
--- a/assets/icons/navigation-menu.svg
+++ b/assets/icons/navigation-menu.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 10H15M1 4H19M1 16H19" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,10 +14,17 @@ const Header: FC<{
   title: string;
   campaignHandle: string;
   announcement?: string;
-  categories: string[];
-  products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
-  setProducts: (products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]) => void 
-}> = ({ campaignHandle, title, announcement, categories, products, setProducts }) => {
+  categories?: string[];
+  products?: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
+  setProducts?: (products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]) => void 
+}> = ({ 
+  campaignHandle, 
+  title, 
+  announcement, 
+  categories = [], 
+  products = [], 
+  setProducts = () => {} 
+}) => {
   const {
     global: { primaryColor, logoPosition },
   } = useTheme();

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React, { MouseEvent } from "react";
 import LogoTitle from "./LogoTitle";
 import { getTextColor } from "@/lib/helper/colors";
 import AnnouncementBar from "./AnnouncementBar";
@@ -9,20 +9,21 @@ import MiniCart from "./cart/MiniCart";
 import getProductListing from "@/lib/campaign/getProductListing";
 import { useTheme } from "@/context/ThemeProvider";
 import { CampaignProduct } from "@/lib/types";
+import MobileNav from "@/components/navigation/MobileNav";
 
 const Header: FC<{
   title: string;
   campaignHandle: string;
   announcement?: string;
   categories?: string[];
-  products?: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
+  allProducts?: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
   setProducts?: (products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]) => void 
 }> = ({ 
   campaignHandle, 
   title, 
   announcement, 
   categories = [], 
-  products = [], 
+  allProducts = [], 
   setProducts = () => {} 
 }) => {
   const {
@@ -31,8 +32,10 @@ const Header: FC<{
 
   const textColor = getTextColor(primaryColor);
 
-  function filterProducts(category: string) {
-    setProducts(products.filter((prod) => prod.tags.includes(category)))
+  function filterProducts(event: MouseEvent<HTMLElement>, category: string = null) {
+    event.preventDefault();
+
+    category ? setProducts(allProducts.filter((prod) => prod.tags.includes(category))) : setProducts(allProducts);
   }
 
   return (
@@ -42,7 +45,7 @@ const Header: FC<{
     >
       {announcement && <AnnouncementBar announcement={announcement} />}
 
-      <Container className="grid w-full grid-cols-[1fr_3fr_1fr] items-center justify-between transition-all lg:relative lg:grid-cols-3 lg:px-16 lg:py-4">
+      <Container className="grid w-full grid-cols-[1fr_3fr_1fr] items-center justify-between transition-all lg:relative lg:px-16 lg:py-4">
         <div
           className={classNames({
             "col-start-1": logoPosition === "center",
@@ -53,20 +56,33 @@ const Header: FC<{
         <LogoTitle
           title={title}
           handle={campaignHandle}
-          className={classNames({
-            "col-start-1 text-left": logoPosition !== "center",
-            "col-start-2 justify-center text-center": logoPosition === "center",
-          })}
+          className={`row-start-1 col-start-2 justify-center ${classNames({
+            "lg:col-start-1 lg:justify-start text-left": logoPosition !== "center",
+            "lg:col-start-2 text-center": logoPosition === "center",
+          })}`}
           color={textColor}
         />
 
-        <ul>
-          {categories.map((category) => (
-            <li><a onClick={() => filterProducts(category)} href="#">{category.replace("atelier:", "")}</a></li>
-          ))}
-        </ul>
+        <div className="header-menu row-start-1 col-start-1 lg:col-start-2 items-center justify-end">
+          {/* Desktop Navigation */}
+          <ul className={`hidden lg:grid grid-cols-${(categories.length+1) > 4 ? "4" : categories.length+1} text-center`}>
+            <li>
+              <a className="cursor-pointer" onClick={(event) => filterProducts(event)}>All</a>
+            </li>
+            {categories.map((category) => (
+              <li>
+                <a className="cursor-pointer" onClick={(event) => filterProducts(event, category)}>{category.replace("atelier:", "")}</a>
+              </li>
+            ))}
+          </ul>
+          {/* Mobile Navigation */}
+          <div className="lg:hidden">
+            <MobileNav categories={categories} onClick={filterProducts} />
+          </div>
+        </div>
+        
 
-        <div className="col-start-3 flex h-[40px] items-center justify-end">
+        <div className="row-start-1 col-start-3 flex h-[40px] items-center justify-end">
           <MiniCart />
         </div>
       </Container>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import LogoTitle from "./LogoTitle";
 import { getTextColor } from "@/lib/helper/colors";
 import AnnouncementBar from "./AnnouncementBar";
@@ -8,7 +9,6 @@ import { FC } from "react";
 import MiniCart from "./cart/MiniCart";
 import getProductListing from "@/lib/campaign/getProductListing";
 import { useTheme } from "@/context/ThemeProvider";
-import { CampaignProduct } from "@/lib/types";
 import MobileNav from "@/components/navigation/MobileNav";
 
 const Header: FC<{
@@ -29,13 +29,24 @@ const Header: FC<{
   const {
     global: { primaryColor, logoPosition },
   } = useTheme();
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   const textColor = getTextColor(primaryColor);
 
   function filterProducts(event: MouseEvent<HTMLElement>, category: string = null) {
     event.preventDefault();
 
+    // Set products to display
     category ? setProducts(allProducts.filter((prod) => prod.tags.includes(category))) : setProducts(allProducts);
+
+    // Set query string
+    if(category) {
+      router.replace(`${pathname}?category=${category}`);
+    } else {
+      router.replace(pathname);
+    }
   }
 
   return (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,3 +1,4 @@
+import React, { Dispatch, SetStateAction } from "react";
 import LogoTitle from "./LogoTitle";
 import { getTextColor } from "@/lib/helper/colors";
 import AnnouncementBar from "./AnnouncementBar";
@@ -5,18 +6,27 @@ import Container from "./general/Container";
 import classNames from "classnames";
 import { FC } from "react";
 import MiniCart from "./cart/MiniCart";
+import getProductListing from "@/lib/campaign/getProductListing";
 import { useTheme } from "@/context/ThemeProvider";
+import { CampaignProduct } from "@/lib/types";
 
 const Header: FC<{
   title: string;
   campaignHandle: string;
   announcement?: string;
-}> = ({ campaignHandle, title, announcement }) => {
+  categories: string[];
+  products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
+  setProducts: (products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]) => void 
+}> = ({ campaignHandle, title, announcement, categories, products, setProducts }) => {
   const {
     global: { primaryColor, logoPosition },
   } = useTheme();
 
   const textColor = getTextColor(primaryColor);
+
+  function filterProducts(category: string) {
+    setProducts(products.filter((prod) => prod.tags.includes(category)))
+  }
 
   return (
     <div
@@ -42,6 +52,12 @@ const Header: FC<{
           })}
           color={textColor}
         />
+
+        <ul>
+          {categories.map((category) => (
+            <li><a onClick={() => filterProducts(category)} href="#">{category.replace("atelier:", "")}</a></li>
+          ))}
+        </ul>
 
         <div className="col-start-3 flex h-[40px] items-center justify-end">
           <MiniCart />

--- a/components/VerticalCombobox.tsx
+++ b/components/VerticalCombobox.tsx
@@ -9,7 +9,7 @@ import {
   } from '@shopify/polaris';
   import {useState, FC, useCallback, useMemo} from 'react';
   
-  const MultiselectTagComboboxExample: FC<{ 
+  const MultiselectTagCombobox: FC<{ 
     selectedTags: string[]; 
     onChange: (selection: string) => void;
   }> = ({ 
@@ -181,4 +181,4 @@ import {
     );
   }
 
-  export default MultiselectTagComboboxExample;
+  export default MultiselectTagCombobox;

--- a/components/campaign/CampaignProductTagForm.tsx
+++ b/components/campaign/CampaignProductTagForm.tsx
@@ -7,7 +7,7 @@ import {
     BlockStack
 } from "@shopify/polaris";
 import { CampaignProduct } from "@/lib/types";
-import MultiselectTagComboboxExample from "@/components/VerticalCombobox";
+import MultiselectTagCombobox from "@/components/VerticalCombobox";
 
 const CampaignProductTagForm: FC<{ 
     product: CampaignProduct;
@@ -89,7 +89,7 @@ const CampaignProductTagForm: FC<{
     return (
         <BlockStack gap="400" inlineAlign="end">
             <div style={{ width: "100%" }}>
-                <MultiselectTagComboboxExample 
+                <MultiselectTagCombobox 
                     selectedTags={tags}
                     onChange={changeSelection}
                 />

--- a/components/navigation/MobileNav.tsx
+++ b/components/navigation/MobileNav.tsx
@@ -1,0 +1,66 @@
+import { useState, MouseEvent } from "react";
+import { Drawer } from "vaul";
+import MenuIcon from "@/assets/icons/navigation-menu.svg";
+import CloseIcon from "@/assets/icons/x.svg";
+
+const MobileNav = ({
+    categories,
+    onClick
+}) => {
+  const [openDrawer, setOpenDrawer] = useState(false);
+
+  function handleClick(event: MouseEvent<HTMLElement>, category:string = null) {
+    onClick(event, category);
+    setOpenDrawer(false);
+  }
+
+  const Body = () =>
+    (
+        <div className="header-menu text-xl font-semibold">
+          <ul className="p-6 grid gap-y-4">
+            <li>
+              <a className="cursor-pointer" onClick={(event) => handleClick(event)}>All</a>
+            </li>
+            {categories.map((category: string) => (
+              <li>
+                <a className="cursor-pointer" onClick={(event) => handleClick(event, category)}>{category.replace("atelier:", "")}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+    )
+
+
+  return (
+    <Drawer.Root
+      direction="left"
+      open={openDrawer}
+      onOpenChange={setOpenDrawer}
+    >
+      <Drawer.Trigger aria-label="Open mobile nav drawer" className="relative">
+        <MenuIcon />
+      </Drawer.Trigger>
+
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-10 bg-black/40" />
+
+        <Drawer.Content
+          className="fixed bottom-0 left-0 top-0 z-20 flex h-screen w-full flex-col items-stretch pt-8 md:max-w-sm"
+          style={{
+            backgroundColor: "#ffffff",
+          }}
+        >
+          <header className="flex items-center px-6">
+            <Drawer.Close>
+              <CloseIcon class="u-icon-stroke--black" />
+            </Drawer.Close>
+          </header>
+
+          <Body />
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+};
+
+export default MobileNav;

--- a/lib/campaign/getProductListing.ts
+++ b/lib/campaign/getProductListing.ts
@@ -56,6 +56,7 @@ const getProductListing = async ({
                 currencyCode: string;
               };
             };
+            tags?: string[];
           }[];
         };
       };
@@ -98,6 +99,7 @@ const getProductListing = async ({
                   currencyCode
                 }
               }
+              tags
             }
           }
         }

--- a/pages/[campaign_handle]/index.tsx
+++ b/pages/[campaign_handle]/index.tsx
@@ -72,7 +72,7 @@ const CampaignPage: FC<PageProps> = ({
         title={collection.title}
         campaignHandle={collection.handle}
         announcement={announcement}
-        products={prodList}
+        allProducts={listing.products.nodes}
         setProducts={setProdList}
         categories={prodCategories}
       />


### PR DESCRIPTION
### WHAT IT DOES:

Created category navigation & corresponding filter functionality.
The categories appear according to the product tags that begin with `atelier:`.
In our demo, there are three atelier tags (`atelier:Category 1`, `atelier:Category 2`, `atelier:Category 3`), which appear as **Category 1**, **Category 2**, and **Category 3**

### WHAT TO TEST:

Try clicking on the navigation buttons (including mobile), and see how the campaign page filters out the products.

### PREVIEW:

Desktop Navigation

![image](https://github.com/lumberdev/atelier/assets/43429460/94353639-ab48-4170-95f4-110053439e37)

Mobile Navigation

![image](https://github.com/lumberdev/atelier/assets/43429460/a5c9932d-3851-43dc-8890-5b49444f748f)

![image](https://github.com/lumberdev/atelier/assets/43429460/5c11b7bd-96a1-407e-9ca7-5e517a7794fb)

Products getting filtered

![image](https://github.com/lumberdev/atelier/assets/43429460/3fd7b2a2-4583-49f6-868e-456fea3e1b17)


