### PR TITLE
Bugfix with the image selection

### DIFF
--- a/components/campaign/AccessControlFormSlice.tsx
+++ b/components/campaign/AccessControlFormSlice.tsx
@@ -20,6 +20,7 @@ const CampaignAccessControlFormSlice = ({
   imageUrl,
   imageFile,
   setImageFile,
+  setDidSelectImageFile,
   isLoading,
 }: {
   control: ReturnType<typeof useCampaignForm>["control"];
@@ -27,6 +28,7 @@ const CampaignAccessControlFormSlice = ({
   imageUrl: ReturnType<typeof useCampaignForm>["imageUrl"];
   imageFile: ReturnType<typeof useCampaignForm>["imageFile"];
   setImageFile: ReturnType<typeof useCampaignForm>["setImageFile"];
+  setDidSelectImageFile: ReturnType<typeof useCampaignForm>["setDidSelectImageFile"];
   isLoading: boolean;
 }) => {
   const [useCTA, setUseCTA] = useState<boolean>(false);
@@ -40,6 +42,11 @@ const CampaignAccessControlFormSlice = ({
 
     setUseCTA(true);
   }, [ctaText]);
+
+  function removeImage() {
+    setImageFile(null);
+    setDidSelectImageFile(true);
+  }
 
   return (
     <Card>
@@ -123,7 +130,7 @@ const CampaignAccessControlFormSlice = ({
               render={({ field }) => (
                 <TextField
                   label="Field Placeholder"
-                  helpText="This will show when he password field is empty. ie Enter Password"
+                  helpText="This will show when the password field is empty. ie Enter Password"
                   autoComplete="false"
                   disabled={isLoading}
                   {...field}
@@ -153,7 +160,7 @@ const CampaignAccessControlFormSlice = ({
                 <Button
                   variant="plain"
                   tone="critical"
-                  onClick={() => setImageFile(null)}
+                  onClick={() => removeImage()}
                 >
                   Remove
                 </Button>

--- a/components/campaign/AccessControlFormSlice.tsx
+++ b/components/campaign/AccessControlFormSlice.tsx
@@ -157,13 +157,13 @@ const CampaignAccessControlFormSlice = ({
                   {layout === "DEFAULT" ? "Background Image" : "Image"}
                 </Text>
 
-                <Button
+                {imageFile && <Button
                   variant="plain"
                   tone="critical"
                   onClick={() => removeImage()}
                 >
                   Remove
-                </Button>
+                </Button>}
               </InlineStack>
 
               <DropZone

--- a/components/campaign/Page.tsx
+++ b/components/campaign/Page.tsx
@@ -60,6 +60,7 @@ const CampaignPage: FC<{
     watch,
     setImageFile,
     didSelectImageFile,
+    setDidSelectImageFile,
   } = useCampaignForm({
     initialValues: campaign,
     handle: collection.handle,
@@ -238,6 +239,7 @@ const CampaignPage: FC<{
                 imageUrl={imageUrl}
                 imageFile={imageFile}
                 setImageFile={setImageFile}
+                setDidSelectImageFile={setDidSelectImageFile}
               />
             </Layout.AnnotatedSection>
 

--- a/lib/hooks/app/useCampaignForm.ts
+++ b/lib/hooks/app/useCampaignForm.ts
@@ -129,6 +129,7 @@ export const useCampaignForm = ({
 
         onUpdate();
         form.reset(campaign);
+        setDidSelectImageFile(false);
       },
     }
   );
@@ -177,5 +178,6 @@ export const useCampaignForm = ({
     imageUrl,
     imageFile,
     setImageFile,
+    setDidSelectImageFile
   };
 };


### PR DESCRIPTION
### WHAT IT DOES:

Fixed a bug with the background image selector of the campaign password page.

### WHAT TO TEST:

Go to the campaign edit page, and try the following:

- [ ] Ensure that "Remove" button is working properly
- [ ] Try changing the image, and saving it

