### PR TITLE
Fix 500 error with product page

### DIFF
--- a/lib/campaign/getProductDetails.ts
+++ b/lib/campaign/getProductDetails.ts
@@ -34,16 +34,6 @@ const getProductDetails = async ({
             currencyCode: string;
           };
         };
-        compareAtPriceRange: {
-          maxVariantCompareAtPrice: {
-            amount: string;
-            currencyCode: string;
-          };
-          minVariantCompareAtPrice: {
-            amount: string;
-            currencyCode: string;
-          };
-        };
         hasOnlyDefaultVariant: boolean;
         mediaCount: number;
         options: {
@@ -107,16 +97,6 @@ const getProductDetails = async ({
             }
 
             minVariantPrice {
-              amount
-              currencyCode
-            }
-          }
-          compareAtPriceRange {
-            maxVariantCompareAtPrice {
-              amount
-              currencyCode
-            }
-            minVariantCompareAtPrice {
               amount
               currencyCode
             }


### PR DESCRIPTION
### WHAT IT DOES:

- 500 error fixed on PDP (`compareAtPriceRange` field removed in `Product` query

