### PR TITLE
Pratik/bug/fix nav layout

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,33 +16,42 @@ const Header: FC<{
   campaignHandle: string;
   announcement?: string;
   categories?: string[];
-  allProducts?: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"];
-  setProducts?: (products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]) => void 
-}> = ({ 
-  campaignHandle, 
-  title, 
-  announcement, 
-  categories = [], 
-  allProducts = [], 
-  setProducts = () => {} 
+  allProducts?: Awaited<
+    ReturnType<typeof getProductListing>
+  >["products"]["nodes"];
+  setProducts?: (
+    products: Awaited<ReturnType<typeof getProductListing>>["products"]["nodes"]
+  ) => void;
+}> = ({
+  campaignHandle,
+  title,
+  announcement,
+  categories = [],
+  allProducts = [],
+  setProducts = () => {},
 }) => {
   const {
     global: { primaryColor, logoPosition },
   } = useTheme();
-  const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const textColor = getTextColor(primaryColor);
 
-  function filterProducts(event: MouseEvent<HTMLElement>, category: string = null) {
+  function filterProducts(
+    event: MouseEvent<HTMLElement>,
+    category: string = null
+  ) {
     event.preventDefault();
 
     // Set products to display
-    category ? setProducts(allProducts.filter((prod) => prod.tags.includes(category))) : setProducts(allProducts);
+    category
+      ? setProducts(allProducts.filter((prod) => prod.tags.includes(category)))
+      : setProducts(allProducts);
 
     // Set query string
-    if(category) {
+    if (category) {
       router.replace(`${pathname}?category=${category}`);
     } else {
       router.replace(pathname);
@@ -67,25 +76,35 @@ const Header: FC<{
         <LogoTitle
           title={title}
           handle={campaignHandle}
-          className={`row-start-1 col-start-2 justify-center ${classNames({
-            "lg:col-start-1 lg:justify-start text-left": logoPosition !== "center",
-            "lg:col-start-2 text-center": logoPosition === "center",
+          className={`col-start-2 row-start-1 justify-center ${classNames({
+            "text-left lg:col-start-1 lg:justify-start":
+              logoPosition !== "center",
+            "text-center lg:col-start-2": logoPosition === "center",
           })}`}
           color={textColor}
         />
 
-        <div className="header-menu row-start-1 col-start-1 lg:col-start-2 items-center justify-end">
+        <div className="header-menu col-start-1 row-start-1 items-center justify-end lg:col-start-2">
           {/* Desktop Navigation */}
-          <ul className={`hidden lg:grid text-center ${classNames({
-            "grid-cols-4": categories.length >= 3,
-            "grid-cols-3": categories.length < 3,
-          })}`}>
+          <ul
+            className={`hidden items-center justify-center gap-12 text-center lg:flex`}
+          >
             <li>
-              <a className="cursor-pointer" onClick={(event) => filterProducts(event)}>All</a>
+              <a
+                className="cursor-pointer"
+                onClick={(event) => filterProducts(event)}
+              >
+                All
+              </a>
             </li>
             {categories.map((category) => (
               <li>
-                <a className="cursor-pointer" onClick={(event) => filterProducts(event, category)}>{category.replace("atelier:", "")}</a>
+                <a
+                  className="cursor-pointer"
+                  onClick={(event) => filterProducts(event, category)}
+                >
+                  {category.replace("atelier:", "")}
+                </a>
               </li>
             ))}
           </ul>
@@ -94,9 +113,8 @@ const Header: FC<{
             <MobileNav categories={categories} onClick={filterProducts} />
           </div>
         </div>
-        
 
-        <div className="row-start-1 col-start-3 flex h-[40px] items-center justify-end">
+        <div className="col-start-3 row-start-1 flex h-[40px] items-center justify-end">
           <MiniCart />
         </div>
       </Container>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -31,7 +31,7 @@ const Header: FC<{
   setProducts = () => {},
 }) => {
   const {
-    global: { primaryColor, logoPosition },
+    global: { primaryColor, logoPosition, logo },
   } = useTheme();
   const router = useRouter();
   const pathname = usePathname();
@@ -73,21 +73,33 @@ const Header: FC<{
           })}
         />
 
-        <LogoTitle
-          title={title}
-          handle={campaignHandle}
-          className={`col-start-2 row-start-1 justify-center ${classNames({
-            "text-left lg:col-start-1 lg:justify-start":
-              logoPosition !== "center",
-            "text-center lg:col-start-2": logoPosition === "center",
-          })}`}
-          color={textColor}
-        />
+        {!!logo && (
+          <LogoTitle
+            title={title}
+            handle={campaignHandle}
+            className={`col-start-2 row-start-1 justify-center ${classNames({
+              "text-left lg:col-start-1 lg:justify-start":
+                logoPosition !== "center",
+              "text-center lg:col-start-2": logoPosition === "center",
+            })}`}
+            logo={logo}
+          />
+        )}
 
-        <div className="header-menu col-start-1 row-start-1 items-center justify-end lg:col-start-2">
+        <div
+          className={`header-menu col-start-1 row-start-1 items-center justify-end
+            ${classNames({
+              "lg:col-start-2": logoPosition !== "center",
+              "lg:col-start-1": logoPosition === "center" || !logo,
+            })}`}
+        >
           {/* Desktop Navigation */}
           <ul
-            className={`hidden items-center justify-center gap-12 text-center lg:flex`}
+            className={`hidden items-center justify-center gap-12 text-center lg:flex ${classNames(
+              {
+                "lg:justify-start": logoPosition === "center" || !logo,
+              }
+            )}`}
           >
             <li>
               <a

--- a/components/LogoTitle.tsx
+++ b/components/LogoTitle.tsx
@@ -1,33 +1,32 @@
+import React from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { useTheme } from "@/context/ThemeProvider";
 
-const LogoTitle = ({ title, handle, color = "black", className = "" }) => {
-  const {
-    global: { logo },
-  } = useTheme();
+interface LogoTitleProps {
+  title: string;
+  handle: string;
+  logo: string;
+  className?: string;
+}
 
+const LogoTitle: React.FC<LogoTitleProps> = ({
+  title,
+  handle,
+  logo,
+  className = "",
+}) => {
   return (
     <Link
       href={`/${handle}`}
       className={`flex items-center no-underline ${className}`}
     >
-      {logo ? (
-        <Image
-          width={100}
-          height={100}
-          src={logo}
-          alt={title}
-          className="mx-auto h-[3rem] w-auto py-2 lg:mx-0"
-        />
-      ) : (
-        <h1
-          className="mx-1 py-0 text-xl text-black lg:py-4 lg:text-3xl"
-          style={{ color: color }}
-        >
-          {title}
-        </h1>
-      )}
+      <Image
+        width={100}
+        height={100}
+        src={logo}
+        alt={title}
+        className="mx-auto h-[3rem] w-auto py-2 lg:mx-0"
+      />
     </Link>
   );
 };

--- a/components/campaign/CartCustomizationFormSlice.tsx
+++ b/components/campaign/CartCustomizationFormSlice.tsx
@@ -14,7 +14,6 @@ const CartCustomizationFormSlice: FC<{
   control: Control<FieldValues>;
   isLoading: boolean;
 }> = ({ control, isLoading }) => {
-
   return (
     <Card>
       <BlockStack gap="400">
@@ -50,12 +49,12 @@ const CartCustomizationFormSlice: FC<{
         <Controller
           control={control}
           name="cartTextColor"
-          render={({ field }) => (
-            <TextField
+          render={({ field: { onChange, name, value } }) => (
+            <ThemeColorPicker
               label="Text Color"
-              autoComplete="off"
-              disabled={isLoading}
-              {...field}
+              onChangeField={onChange}
+              fieldName={name}
+              colorValue={value}
             />
           )}
         />


### PR DESCRIPTION
### WHAT IT DOES:

1. Adjust alignment of Nav Menu for cases with low number of menu items
2. If no logo has been uploaded, remove the exiting backup title text and shift nav menu to left


### WHAT TO TEST:

_Add steps or instructions on what should be tested before approving_

- [ ] some task
- [ ]

### PREVIEW:

Left Align Meny Items when no logo present:
<img width="1025" alt="image" src="https://github.com/lumberdev/atelier/assets/52301822/51026a3e-3732-4ad8-8b15-57136d696662">


Center Aligning Nav Menu Items:
<img width="1498" alt="image" src="https://github.com/lumberdev/atelier/assets/52301822/727fb45e-d185-48e8-b657-d0d5e3abddc6">

