### PR TITLE
Bug/navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -84,31 +84,40 @@ const Header: FC<{
           })}
         />
 
-
-          <LogoTitle
-            title={title}
-            handle={campaignHandle}
-            className={`col-start-2 row-start-1 justify-center ${classNames({
-              "text-left lg:col-start-1 lg:justify-start":
-                logoPosition !== "center",
-              "text-center lg:col-start-2": logoPosition === "center",
-            })}`}
-            logo={logo}
-          />
-
+        {
+          logo ? (
+            <LogoTitle
+              title={title}
+              handle={campaignHandle}
+              className={`col-start-2 row-start-1 justify-center ${classNames({
+                "text-left lg:col-start-1 lg:justify-start":
+                  logoPosition !== "center",
+                "text-center lg:col-start-2": logoPosition === "center",
+              })}`}
+              logo={logo}
+            />
+          ) : title && (
+            <h1 className={`col-start-2 row-start-1 justify-center ${classNames({
+              "text-left lg:col-start-1 lg:justify-start" : logoPosition !== "center",
+              "text-center lg:col-start-2": logoPosition === "center"
+            })}`}>
+              {title}
+            </h1>
+          )
+        }
 
         <div
           className={`header-menu col-start-1 row-start-1 items-center justify-end
             ${classNames({
-              "lg:col-start-2": logoPosition !== "center",
-              "lg:col-start-1": logoPosition === "center" || !logo,
+              "lg:col-start-2": (logo || title) && logoPosition !== "center",
+              "lg:col-start-1": logoPosition === "center" || (!logo && !title),
             })}`}
         >
           {/* Desktop Navigation */}
           <ul
             className={`hidden items-center justify-center gap-12 text-center lg:flex ${classNames(
               {
-                "lg:justify-start": logoPosition === "center" || !logo,
+                "lg:justify-start": logoPosition === "center" || (!logo && !title),
               }
             )}`}
           >

--- a/pages/[campaign_handle]/[product_handle]/index.tsx
+++ b/pages/[campaign_handle]/[product_handle]/index.tsx
@@ -26,12 +26,13 @@ const ProductDetailPage: FC<PageProps> = ({
   product,
   announcement,
   announcementBgColor,
-  announcementTextColor
+  announcementTextColor,
+  campaignTitle,
 }) => {
   return (
     <div className="min-h-screen">
       <Header
-        title={product.title}
+        title={campaignTitle}
         campaignHandle={collection.handle}
         announcement={announcement}
         announcementBgColor={announcementBgColor}
@@ -135,6 +136,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
       announcement: campaign.announcement,
       announcementBgColor: campaign.announcementBgColor,
       announcementTextColor: campaign.announcementTextColor,
+      campaignTitle: campaign.pageTitle,
       shop: merchant.shop,
       storefrontAccessToken,
       themeConfig,

--- a/pages/[campaign_handle]/index.tsx
+++ b/pages/[campaign_handle]/index.tsx
@@ -60,7 +60,7 @@ const CampaignPage: FC<PageProps> = ({
   return (
     <div className="min-h-screen">
       <Header
-        title={collection.title}
+        title={campaignTitle}
         campaignHandle={collection.handle}
         announcement={announcement}
         announcementBgColor={announcementBgColor}


### PR DESCRIPTION
### WHAT IT DOES:

- Change alt text to be **page title** instead of the campaign title
- Shift category navigation to left if there is no logo nor page title present

### WHAT TO TEST:

- [ ] Try removing logo and page title, and set logo position to left. Then check if the category navigation is still shifted to the left.
- [ ] Remove logo and set a page title. Watch page title appear on the designated logo position.

### PREVIEW:

Page title

![image](https://github.com/lumberdev/atelier/assets/43429460/6fc47828-1d96-4846-a714-debb9f4d47a0)

![image](https://github.com/lumberdev/atelier/assets/43429460/1b5f0b9e-b0c7-423d-a234-7b001dabb719)


No logo & no page title

![image](https://github.com/lumberdev/atelier/assets/43429460/3df3bf0a-4594-405f-935e-353d7800d5fd)

![image](https://github.com/lumberdev/atelier/assets/43429460/3943553c-98dd-4451-9e1a-f00555021c0c)

![image](https://github.com/lumberdev/atelier/assets/43429460/f38b4306-a46a-4a12-beff-6640af4b57e4)


