### PR TITLE
mandatory webhook response

### DIFF
--- a/pages/api/gdpr/customers_data_request.js
+++ b/pages/api/gdpr/customers_data_request.js
@@ -7,6 +7,8 @@ const handler = async (req, res) => {
   const { body } = req;
   const shop = req.body.shop_domain;
   console.log("gdpr/customers_data_request", body, shop);
+  
+  return res.status(200).send(`customer data request completed on ${shop}`);
 };
 
 export default withMiddleware("verifyHmac")(handler);

--- a/pages/api/gdpr/customers_redact.js
+++ b/pages/api/gdpr/customers_redact.js
@@ -7,6 +7,8 @@ const handler = async (req, res) => {
   const { body } = req;
   const shop = req.body.shop_domain;
   console.log("gdpr/customers_redact", body, shop);
+
+  return res.status(200).send(`customer redact completed on ${shop}`);
 };
 
 export default withMiddleware("verifyHmac")(handler);

--- a/pages/api/gdpr/shop_redact.js
+++ b/pages/api/gdpr/shop_redact.js
@@ -7,6 +7,8 @@ const handler = async (req, res) => {
   const { body } = req;
   const shop = req.body.shop_domain;
   console.log("gdpr/shop_redact", body, shop);
+
+  return res.status(200).send(`shop redact completed on ${shop}`);
 };
 
 export default withMiddleware("verifyHmac")(handler);


### PR DESCRIPTION
### WHAT IT DOES:
- Added mandatory compliance webhooks for customer deletion, customer data request, and store deletion

### WHAT TO TEST:

- [ ] Update the **Compliance webhooks** in Shopify Partners app configuration to the following urls accordingly:
  - Customer data request endpoint: `https://<your-domain>/api/gdpr/customers_data_request`
  - Customer data erasure endpoint: `https;//<your-domain>/api/gdpr/customers_redact`
  - Shop data erasure endpoint: `https://<your-domain>/api/gdpr/shop_redact`
- [ ] In river theme, try creating a customer, and deleting it - if you check the console (the one running ngrok), it should return 200 OK status
