### PR TITLE
Beta subscription pricing + preview mode bugfix

### DIFF
--- a/components/PreviewModeBanner.tsx
+++ b/components/PreviewModeBanner.tsx
@@ -39,7 +39,7 @@ const PreviewModeBanner: FC<{ canPreviewAccessPage?: boolean }> = ({
                 onChange={({ target: { value } }) => {
                   if (value === "password")
                     return router.push(
-                      "/" + router.asPath.split("/")[1] + "/password"
+                      router.asPath.split("?")[0] + "/password"
                     );
 
                   router.push(router.asPath.split("/password")[0]);

--- a/components/campaign/CartCustomizationFormSlice.tsx
+++ b/components/campaign/CartCustomizationFormSlice.tsx
@@ -18,7 +18,7 @@ const CartCustomizationFormSlice: FC<{
     <Card>
       <BlockStack gap="400">
         <Text variant="headingSm" as="h3">
-          Store Details
+          Cart Details
         </Text>
 
         <Controller

--- a/context/BillingProvider.tsx
+++ b/context/BillingProvider.tsx
@@ -15,7 +15,7 @@ import { useMutation, useQuery } from "react-query";
 interface IBillingContext {
   subscription?: CurrentSubscription;
   subsLoading: boolean;
-  subscribe: ({ plan }: { plan: "STARTER" | "PREMIUM" }) => void;
+  subscribe: ({ plan }: { plan: "BETA" | "STARTER" | "PREMIUM" }) => void;
   cancel: () => void;
 }
 

--- a/pages/api/apps/billing/index.ts
+++ b/pages/api/apps/billing/index.ts
@@ -63,6 +63,10 @@ router.get(async (req, res) => {
 });
 
 const SUBSCRIPTION_PLAN = {
+  BETA: {
+    name: "Beta",
+    price: 19.0,
+  },
   STARTER: {
     name: "Starter",
     price: 49.0,

--- a/pages/app/onboarding/index.tsx
+++ b/pages/app/onboarding/index.tsx
@@ -6,7 +6,7 @@ import {
   Grid,
   InlineStack,
   Icon,
-  Layout,
+  Link,
   Page,
   Text,
   BlockStack,
@@ -18,84 +18,84 @@ const OnboardingPage = () => {
 
   return (
     <Page>
-      <BlockStack gap="2400">
+      <BlockStack gap="800">
         <BlockStack gap="400">
           <Text as="h1" variant="heading3xl">
-            Select the right plan for you
+            Join our beta
           </Text>
 
-          <Text as="p">All our plans include an 8 week free trial</Text>
+          <Text as="p" variant="bodyLg">
+            Atelier is fully functional but we decided to release a discounted version to early adopters in exchange for feedback.
+            <br />
+            All subscriptions are 90% off for a full year. You  won't be charged during the first 8 weeks.
+          </Text>
         </BlockStack>
 
         <Grid columns={{ sm: 1, md: 2, lg: 2 }}>
           <Grid.Cell>
             <Card>
               <BlockStack gap="400">
-                <Text as="h2" variant="bodyLg">
-                  Starter
+                <Text as="h6" variant="headingMd" fontWeight="medium">
+                  Beta Mode | Free Trial + 90% off
                 </Text>
-                <Text as="p" variant="headingXl">
-                  $49 / month
+                <InlineStack gap="200">
+                  <Text as="span" variant="headingXl" tone="subdued"><s>$199</s></Text>
+                  <Text as="p" variant="headingXl">$19 / month</Text>
+                </InlineStack>
+                <Text as="p" tone="success" fontWeight="semibold">
+                  8 week free trial. Lock in beta pricing for a full year.
                 </Text>
-                <Text as="p" tone="success" fontWeight="bold">
-                  8 week free trial
-                </Text>
 
-                <Divider />
+                <BlockStack gap="600">
+                  <Divider />
+                
+                  <BlockStack gap="200">
+                    <InlineStack align="start" gap="200">
+                      <div>
+                        <Icon source={CheckIcon} tone="success" />
+                      </div>
 
-                <BlockStack gap="200">
-                  <InlineStack align="start" gap="200">
-                    <div>
-                      <Icon source={CheckIcon} tone="success" />
-                    </div>
+                      <Text as="p" variant="bodyLg">
+                        Create unlimited, password-protected private sales
+                      </Text>
+                    </InlineStack>
 
-                    <Text as="p" variant="bodyLg">
-                      Create as many sales as you want
-                    </Text>
-                  </InlineStack>
+                    <InlineStack align="start" gap="200">
+                      <div>
+                        <Icon source={CheckIcon} tone="success" />
+                      </div>
 
-                  <InlineStack align="start" gap="200">
-                    <div>
-                      <Icon source={CheckIcon} tone="success" />
-                    </div>
+                      <Text as="p" variant="bodyLg">
+                        Publish collections exclusively to Atelier
+                      </Text>
+                    </InlineStack>
 
-                    <Text as="p" variant="bodyLg">
-                      Add all the products you want
-                    </Text>
-                  </InlineStack>
+                    <InlineStack align="start" gap="200">
+                      <div>
+                        <Icon source={CheckIcon} tone="success" />
+                      </div>
 
-                  <InlineStack align="start" gap="200">
-                    <div>
-                      <Icon source={CheckIcon} tone="success" />
-                    </div>
+                      <Text as="p" variant="bodyLg">
+                        White glove support for a full year
+                      </Text>
+                    </InlineStack>
+                  </BlockStack>
 
-                    <Text as="p" variant="bodyLg">
-                      Password protect your sale
-                    </Text>
-                  </InlineStack>
-
-                  <InlineStack align="start" gap="200">
-                    <div>
-                      <Icon source={MinusIcon} tone="subdued" />
-                    </div>
-
-                    <Text as="p" variant="bodyLg" tone="subdued">
-                      <s>Remove Atelier branding</s>
-                    </Text>
-                  </InlineStack>
+                  <Button
+                    variant="primary"
+                    onClick={() => subscribe({ plan: "BETA" })}
+                  >
+                    Subscribe to Beta
+                  </Button>
                 </BlockStack>
-
-                <Button
-                  variant="primary"
-                  onClick={() => subscribe({ plan: "STARTER" })}
-                >
-                  Subscribe to Starter
-                </Button>
               </BlockStack>
             </Card>
           </Grid.Cell>
 
-          <Grid.Cell>
+          {/**
+           * PRO PLAN COMING SOON!!
+           */}
+          {/* <Grid.Cell>
             <Card>
               <BlockStack gap="400">
                 <Text as="h2" variant="bodyLg">
@@ -160,8 +160,16 @@ const OnboardingPage = () => {
                 </Button>
               </BlockStack>
             </Card>
-          </Grid.Cell>
+          </Grid.Cell> */}
         </Grid>
+
+        <Text as="p" variant="bodyLg">
+          Any questions? Reach out to 
+          <Link monochrome url="mailto:atelier@lumber.dev" removeUnderline>
+            <b> atelier@lumber.dev</b>
+          </Link>
+          .
+        </Text>
       </BlockStack>
     </Page>
   );


### PR DESCRIPTION
### WHAT IT DOES:

- Preview mode bugfix
- Added Beta pricing for subscription

### WHAT TO TEST:

- [ ] Try changing subscription to beta version, and see if the price shows as $19
- [ ] On the preview mode, click on one of the categories, and then switch the preview mode to password page. This should successfully redirect to the password preview page.

### PREVIEW:

New subscription plan 

![image](https://github.com/lumberdev/atelier/assets/43429460/00c5f657-4457-4863-9b8d-92d40d996673)

![image](https://github.com/lumberdev/atelier/assets/43429460/2e4bea50-a504-4195-ab07-756c3c9e21fb)

![image](https://github.com/lumberdev/atelier/assets/43429460/96be6b5b-08f6-4f07-99ca-f6d9d2504d8d)

